### PR TITLE
Add Cursor Cloud development environment setup instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -162,3 +162,27 @@ Main exported symbols (see PacletInfo.wl):
 - Context aliases (e.g., ``sp`PrivateHoldNotValidQ``) reduce symbol verbosity
 - The build system integrates with GitHub Actions for automated releases
 - Release metadata (`$RELEASE_ID$`, etc.) is templated in PacletInfo.wl and replaced during CI builds
+
+## Cursor Cloud specific instructions
+
+### Runtime environment
+
+Wolfram Engine 14.1 runs inside a Docker container (`wolframresearch/wolframengine:14.1`). A persistent container named `wolfram-dev` is created with `build-essential` pre-installed (required for C compilation via `CCompilerDriver`). A `/usr/local/bin/wolframscript` wrapper script delegates to this container, mounting `/workspace` so all repo paths work transparently.
+
+The `WOLFRAMSCRIPT_ENTITLEMENTID` secret must be configured for licensing. When set, the wrapper passes it through to the container along with the `WOLFRAMINIT` env var.
+
+### Key commands
+
+| Task | Command |
+|------|---------|
+| Compile C libraries | `wolframscript -f Scripts/Compile.wls` |
+| Build paclet | `wolframscript -f Scripts/BuildPaclet.wls` (requires cloud publisher auth; MX build succeeds without it) |
+| Run all tests | `wolframscript -f Scripts/TestPaclet.wls` |
+| Load paclet interactively | `wolframscript -code 'PacletDirectoryLoad["/workspace"]; Get["RickHennigan\x60ComputationalFitness\x60"]; ...'` |
+
+### Gotchas
+
+- The `LibraryResources/` directory is not checked into git. You must run `wolframscript -f Scripts/Compile.wls` before the paclet can load FIT files (the C shared libraries are compiled on demand for the current `$SystemID`).
+- The full `BuildPaclet.wls` script validates cloud resource references and will fail without Wolfram Cloud publisher credentials (`RESOURCE_PUBLISHER_TOKEN`). This is expected in local dev; the MX file and C libraries are the important build outputs.
+- If you modify paclet code and an MX file exists at `Kernel/64Bit/ComputationalFitness.mx`, delete it before testing so the kernel loads the source `.wl` files instead of the cached MX.
+- The `wolfram-dev` Docker container must be running for `wolframscript` to work. If it was stopped, restart it with `sudo docker start wolfram-dev`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Cursor Cloud specific instructions to `AGENTS.md` to document the Docker-based development environment for this Wolfram Language paclet.

## Changes

- **`AGENTS.md`**: Added `## Cursor Cloud specific instructions` section documenting:
  - Docker-based Wolfram Engine 14.1 runtime setup (persistent `wolfram-dev` container with `build-essential`)
  - Key commands table for compile/build/test/load
  - Important gotchas: `LibraryResources/` not in git, MX cache invalidation, cloud auth requirements

## Environment Setup

The development environment uses:
- Docker with `wolframresearch/wolframengine:14.1` image
- A persistent `wolfram-dev` container with `build-essential` installed for C compilation
- A `/usr/local/bin/wolframscript` wrapper that delegates to the Docker container
- `WOLFRAMSCRIPT_ENTITLEMENTID` secret for Wolfram Engine licensing

## Verification

All development workflows verified:

| Command | Result |
|---------|--------|
| `wolframscript -f Scripts/Compile.wls` | 5 shared libraries built for Linux-x86-64 |
| `wolframscript -f Scripts/TestPaclet.wls` | 111 tests across 6 suites, all passing |
| FIT/TCX/ZWO import | All 3 formats import successfully |
| Critical Power estimation | Calculated from bike ride data |

[hello_world_output.log](https://cursor.com/agents/bc-11623354-cfb4-47e6-a611-7f21445246a0/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fhello_world_output.log)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-11623354-cfb4-47e6-a611-7f21445246a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-11623354-cfb4-47e6-a611-7f21445246a0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

